### PR TITLE
Added history for key function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.settings/
 /bin/
 /build/
+.DS_Store

--- a/src/main/java/de/metahlfabric/MFContract.java
+++ b/src/main/java/de/metahlfabric/MFContract.java
@@ -495,7 +495,28 @@ public class MFContract implements ContractInterface {
         return helper.createSuccessReturnValue(returnValue);
     }
 
+     /**
+     * Returns the JSON-encoding of a List of MetaObjects representing the history of a specific key.
+     *
+     * @param ctx the hyperledger context object
+     * @param id  the id of the object
+     * @return the JSON string object
+     */
+    @Transaction()
+    public String getAssetHistoryList(Context ctx, String id) {
+        if (!helper.objectExists(ctx, id))
+            return helper.createReturnValue("400", "The object with the key " + id + " does not exist");
 
+        
+        ArrayList<MetaObject> historyForObject = helper.getObjectHistoryFromKey(ctx, id);
+        JsonArray jsonArray = new JsonArray();
+        Iterator<MetaObject> it = historyForObject.iterator();
+        while(it.hasNext()) {
+            jsonArray.add(it.next().toJSON());
+        }
+        //String returnValue = new Gson().toJson(historyForObject, JsonArray.class);
+        return helper.createSuccessReturnValue(jsonArray);
+    }
 
     /**
      * Query the local state database (Couch DB query indexes)

--- a/src/main/java/de/metahlfabric/Utils.java
+++ b/src/main/java/de/metahlfabric/Utils.java
@@ -4,8 +4,12 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.hyperledger.fabric.contract.Context;
+import org.hyperledger.fabric.shim.ledger.KeyModification;
+import org.hyperledger.fabric.shim.ledger.QueryResultsIterator;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.ArrayList;
 
 /**
  * Helper class for the {@link MFContract}.
@@ -152,6 +156,23 @@ public class Utils {
     public MetaObject getMetaObject(Context ctx, String id) {
         return new Gson().fromJson(new String(ctx.getStub().getState(id), UTF_8), MetaObject.class);
     }
+
+     /**
+     * @param ctx the Hyperledger context object
+     * @param id  the corresponding id for the object
+     * @return the MetaObject array of past states
+     */
+    public ArrayList<MetaObject> getObjectHistoryFromKey(Context ctx, String id) {
+        ArrayList<MetaObject> objectHistory = new ArrayList<MetaObject>();
+        QueryResultsIterator<KeyModification> objectChangesIterator = ctx.getStub().getHistoryForKey(id);
+        while(objectChangesIterator.iterator().hasNext()) {
+            KeyModification currentModification = objectChangesIterator.iterator().next();
+            objectHistory.add(new Gson().fromJson(currentModification.getStringValue(), MetaObject.class));
+        }
+        return objectHistory;
+    }
+
+
 
     /**
      * @param ctx     the Hyperledger context object

--- a/src/test/java/de/metahlfabric/MetaChainTest.java
+++ b/src/test/java/de/metahlfabric/MetaChainTest.java
@@ -3,13 +3,16 @@ package de.metahlfabric;
 import org.hyperledger.fabric.contract.Context;
 import org.hyperledger.fabric.shim.ChaincodeStub;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
 
 public final class MetaChainTest {
 
@@ -85,6 +88,31 @@ public final class MetaChainTest {
             assertTrue(result.contains("200"));
         }
 
+    }
+
+    @Nested
+    class TrackObjectTests {
+        @Test
+        @DisplayName("should return a list of transactions for an existing valid object")
+        public void getAssetTransactionHistoryWithValidId() {
+            String[] attributes = {};
+            String[] attrValues = {};
+            String productCreation = contract.createObject(ctx, "AVALIDID1", collection, "milklot", "4", "Liter", attributes, attrValues);
+            assertTrue(productCreation.contains("200"));
+            String id = "AVALIDID1";
+            String result = contract.getAssetHistoryList(ctx, id);
+            assertTrue(result.contains("200"));
+        }
+
+        @Test
+        @DisplayName("should return an exception for an invalid object")
+        public void getAssetTransactionHistoryWithInvalidId() {
+            String id = "SOMEINVALIDSTUFF1";
+            String result = contract.getAssetHistoryList(ctx,id);
+            System.setOut(System.out);
+            System.out.println(result);
+            assertTrue(result.contains("400"));
+        }
     }
 
 }


### PR DESCRIPTION
Implemented the feature mention in #11 using getHistoryForKey in the Hyperledger Fabric Contract API. This is the first attempt and I think the code can be simplified, nonetheless it is a first working version. The function getAssetHistoryList(Context ctx, String id) returns an array of JSON objects (of type MetaObject). Feedback is welcome if I can improve it somewhere.